### PR TITLE
fix for ignoring timezone offset

### DIFF
--- a/django_jalali/db/models.py
+++ b/django_jalali/db/models.py
@@ -239,6 +239,8 @@ class jDateTimeField(models.Field):
         if '.' in datetime_obj:
             try:
                 datetime_obj, usecs = datetime_obj.split('.')
+                if '+' in usecs:
+                    usecs, tz = usecs.split('+')
                 usecs = int(usecs)
             except ValueError:
                 raise exceptions.ValidationError(


### PR DESCRIPTION
If a datetime object includes tz offset (for example when datetime is a 'timestamp with tz' in postgres backend), an exception was raised.
This fix accounts for this case and drops the timzezone.